### PR TITLE
Add Testing Infrastructure and an Example Test Class

### DIFF
--- a/.github/workflows/build_test_lint.yaml
+++ b/.github/workflows/build_test_lint.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - skallaher/testing
   pull_request:
     branches:
       - master

--- a/.github/workflows/build_test_lint.yaml
+++ b/.github/workflows/build_test_lint.yaml
@@ -1,12 +1,16 @@
-name: Build and lint
+name: Build, Test, and Lint
 
 on:
   push:
     branches:
       - master
+      - skallaher/testing
   pull_request:
     branches:
       - master
+
+env:
+  JAVA_VERSION: 1.14
 
 jobs:
   "build":
@@ -16,7 +20,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.14
+          java-version: ${{ env.JAVA_VERSION }}
       - name: Build with Gradle
         run: ./gradlew assemble
   "lint":
@@ -28,6 +32,17 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.14
+          java-version: ${{ env.JAVA_VERSION }}
       - name: Check Spotless
         run: ./gradlew spotlessCheck
+  "test":
+    runs-on: ubuntu-latest
+    needs: "build"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+      - name: Test with Gradle
+        run: ./gradlew test

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "vscjava.vscode-java-test"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,16 @@
     "**/.settings": true,
     "**/.factorypath": true,
     "**/*~": true
+  },
+  "java.test.config": {
+    "name": "WPIlibUnitTests",
+    "workingDirectory": "${workspaceFolder}/build/tmp/jniExtractDir",
+    "vmargs": [
+      "-Djava.library.path=${workspaceFolder}/build/tmp/jniExtractDir"
+    ],
+    "env": {
+      "LD_LIBRARY_PATH": "${workspaceFolder}/build/tmp/jniExtractDir",
+      "DYLD_LIBRARY_PATH": "${workspaceFolder}/build/tmp/jniExtractDir"
+    }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,8 @@ dependencies {
     nativeZip wpi.deps.vendor.jni(wpi.platforms.roborio)
     nativeDesktopZip wpi.deps.vendor.jni(wpi.platforms.desktop)
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.testng:testng:6.9.10'
+    testImplementation 'org.mockito:mockito-core:2.22.0'
 
     // Enable simulation gui support. Must check the box in vscode to enable support
     // upon debugging
@@ -72,6 +73,10 @@ dependencies {
     // Websocket extensions require additional configuration.
     // simulation wpi.deps.sim.ws_server(wpi.platforms.desktop, false)
     // simulation wpi.deps.sim.ws_client(wpi.platforms.desktop, false)
+}
+
+test {
+    useTestNG()
 }
 
 // Simulation configuration (e.g. environment variables).

--- a/src/main/java/com/chargerrobotics/RobotContainer.java
+++ b/src/main/java/com/chargerrobotics/RobotContainer.java
@@ -7,29 +7,11 @@
 
 package com.chargerrobotics;
 
-import edu.wpi.cscore.UsbCamera;
-import edu.wpi.first.cameraserver.CameraServer;
-import edu.wpi.first.wpilibj.GenericHID;
-import edu.wpi.first.wpilibj2.command.CommandScheduler;
-
-import com.chargerrobotics.commands.shooter.HoodCalibrateCommand;
-import com.chargerrobotics.commands.shooter.HoodManualCommand;
-import com.chargerrobotics.commands.shooter.HoodPIDCommand;
-import com.chargerrobotics.commands.shooter.HoodPresetAngleCommand;
-import com.chargerrobotics.commands.shooter.HoodRetractCommand;
-import com.chargerrobotics.commands.shooter.KickerCommand;
-import com.chargerrobotics.commands.shooter.ShooterOffCommand;
-import com.chargerrobotics.commands.shooter.ShooterOnCommand;
-import com.chargerrobotics.sensors.BallSensorSerial;
-import com.chargerrobotics.sensors.ColorSensorSerial;
-import com.chargerrobotics.sensors.GyroscopeSerial;
-import com.chargerrobotics.sensors.ScaleSerial;
 import com.chargerrobotics.commands.autonomous.AutoDriveLinear;
 import com.chargerrobotics.commands.chomper.ChomperCalibrateCommand;
-import com.chargerrobotics.commands.chomper.ChomperIntakeCommand;
-import com.chargerrobotics.commands.chomper.ChomperPIDCommand;
-import com.chargerrobotics.commands.chomper.ChomperUpDownCommand;
 import com.chargerrobotics.commands.chomper.ChomperDownPIDCommand;
+import com.chargerrobotics.commands.chomper.ChomperIntakeCommand;
+import com.chargerrobotics.commands.chomper.ChomperUpDownCommand;
 import com.chargerrobotics.commands.chomper.ChomperUpPIDCommand;
 import com.chargerrobotics.commands.chomper.ChomperVomitCommand;
 import com.chargerrobotics.commands.climber.ClimberDownCommand;
@@ -45,6 +27,18 @@ import com.chargerrobotics.commands.drive.SlowCommand;
 import com.chargerrobotics.commands.feeder.FeederCommand;
 import com.chargerrobotics.commands.groups.VisionDrive;
 import com.chargerrobotics.commands.groups.VisionTurn;
+import com.chargerrobotics.commands.shooter.HoodCalibrateCommand;
+import com.chargerrobotics.commands.shooter.HoodManualCommand;
+import com.chargerrobotics.commands.shooter.HoodPIDCommand;
+import com.chargerrobotics.commands.shooter.HoodPresetAngleCommand;
+import com.chargerrobotics.commands.shooter.HoodRetractCommand;
+import com.chargerrobotics.commands.shooter.KickerCommand;
+import com.chargerrobotics.commands.shooter.ShooterOffCommand;
+import com.chargerrobotics.commands.shooter.ShooterOnCommand;
+import com.chargerrobotics.sensors.BallSensorSerial;
+import com.chargerrobotics.sensors.ColorSensorSerial;
+import com.chargerrobotics.sensors.GyroscopeSerial;
+import com.chargerrobotics.sensors.ScaleSerial;
 import com.chargerrobotics.subsystems.ChomperSubsystem;
 import com.chargerrobotics.subsystems.ClimberSubsystem;
 import com.chargerrobotics.subsystems.ColorSpinnerSubsystem;
@@ -58,253 +52,252 @@ import com.chargerrobotics.subsystems.ShooterSubsystem;
 import com.chargerrobotics.utils.ArduinoSerialReceiver;
 import com.chargerrobotics.utils.Config;
 import com.chargerrobotics.utils.XboxController;
+import edu.wpi.cscore.UsbCamera;
+import edu.wpi.first.cameraserver.CameraServer;
+import edu.wpi.first.wpilibj.GenericHID;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
 
 /**
- * This class is where the bulk of the robot should be declared. Since
- * Command-based is a "declarative" paradigm, very little robot logic should
- * actually be handled in the {@link Robot} periodic methods (other than the
- * scheduler calls). Instead, the structure of the robot (including subsystems,
- * commands, and button mappings) should be declared here.
+ * This class is where the bulk of the robot should be declared. Since Command-based is a
+ * "declarative" paradigm, very little robot logic should actually be handled in the {@link Robot}
+ * periodic methods (other than the scheduler calls). Instead, the structure of the robot (including
+ * subsystems, commands, and button mappings) should be declared here.
  */
 public class RobotContainer {
 
-	private static final boolean limelightEnabled = true;
-	private static final boolean driveEnabled = true;
-	private static final boolean chomperEnabled = true;
-	private static final boolean feedEnabled = true;
-	private static final boolean shooterEnabled = true;
-	private static final boolean shooterHoodEnabled = true;
-	private static final boolean colorSpinnerEnabled = false;
-	private static final boolean climberEnabled = false;
+  private static final boolean limelightEnabled = true;
+  private static final boolean driveEnabled = true;
+  private static final boolean chomperEnabled = true;
+  private static final boolean feedEnabled = true;
+  private static final boolean shooterEnabled = true;
+  private static final boolean shooterHoodEnabled = true;
+  private static final boolean colorSpinnerEnabled = false;
+  private static final boolean climberEnabled = false;
 
-	// Limelight
-	private LimelightSubsystem limelightSubsystem;
+  // Limelight
+  private LimelightSubsystem limelightSubsystem;
 
-	// Align to the target
-	public VisionTurn alignToTarget;
-	public VisionDrive driveToTarget;
+  // Align to the target
+  public VisionTurn alignToTarget;
+  public VisionDrive driveToTarget;
 
-	// Drive
-	private DriveSubsystem driveSubsystem;
-	private ManualDriveCommand manualDriveCommand;
-	private BrakeCommand brakeCommand;
-	private BoostCommand boostCommand;
-	private SlowCommand slowCommand;
-	private AutoDriveLinear autoDriveLinear;
+  // Drive
+  private DriveSubsystem driveSubsystem;
+  private ManualDriveCommand manualDriveCommand;
+  private BrakeCommand brakeCommand;
+  private BoostCommand boostCommand;
+  private SlowCommand slowCommand;
+  private AutoDriveLinear autoDriveLinear;
 
-	// Shooter
-	private ShooterSubsystem shooterSubsystem;
-	private KickerSubsystem kickerSubsystem;
-	private ShooterHoodSubsystem shooterHoodSubsystem;
-	private ShooterOnCommand shooterOnCommand;
-	private ShooterOffCommand shooterOffCommand;
-	private HoodManualCommand hoodManualUpCommand;
-	private HoodManualCommand hoodManualDownCommand;
-	private HoodCalibrateCommand hoodCalibrateCommand;
-	private HoodPIDCommand hoodPIDCommand;
-	private HoodPresetAngleCommand hoodPresetAngleCommand;
-	private HoodRetractCommand hoodRetractCommand;
-	private KickerCommand kickerCommand;
+  // Shooter
+  private ShooterSubsystem shooterSubsystem;
+  private KickerSubsystem kickerSubsystem;
+  private ShooterHoodSubsystem shooterHoodSubsystem;
+  private ShooterOnCommand shooterOnCommand;
+  private ShooterOffCommand shooterOffCommand;
+  private HoodManualCommand hoodManualUpCommand;
+  private HoodManualCommand hoodManualDownCommand;
+  private HoodCalibrateCommand hoodCalibrateCommand;
+  private HoodPIDCommand hoodPIDCommand;
+  private HoodPresetAngleCommand hoodPresetAngleCommand;
+  private HoodRetractCommand hoodRetractCommand;
+  private KickerCommand kickerCommand;
 
-	// Chomper
-	private ChomperSubsystem chomperSubsystem;
-	private ChomperCalibrateCommand chomperCalibrateCommand;
-	private ChomperIntakeCommand chomperIntakeCommand;
-	private ChomperVomitCommand chomperVomitCommand;
-	private ChomperUpPIDCommand chomperUpCommand;
-	private ChomperDownPIDCommand chomperDownCommand;
-	private ChomperUpDownCommand manualchomperUpCommand;
-	private ChomperUpDownCommand manualchomperDownCommand;
+  // Chomper
+  private ChomperSubsystem chomperSubsystem;
+  private ChomperCalibrateCommand chomperCalibrateCommand;
+  private ChomperIntakeCommand chomperIntakeCommand;
+  private ChomperVomitCommand chomperVomitCommand;
+  private ChomperUpPIDCommand chomperUpCommand;
+  private ChomperDownPIDCommand chomperDownCommand;
+  private ChomperUpDownCommand manualchomperUpCommand;
+  private ChomperUpDownCommand manualchomperDownCommand;
 
-	//Feeder
-	private FeedSubsystem feedSubsystem;
-	private FeederCommand feederCommand;
+  // Feeder
+  private FeedSubsystem feedSubsystem;
+  private FeederCommand feederCommand;
 
-	// Color Spinner
-	private ColorSpinnerSubsystem colorSpinnerSubsystem;
-	private ColorSpinnerCommand colorSpinnerCommand;
-	private ColorTargetCommand colorTargetCommand;
-	private ColorSpinnerDeploy colorSpinnerDeploy;
-	private ColorSpinnerRetract colorSpinnerRetract;
+  // Color Spinner
+  private ColorSpinnerSubsystem colorSpinnerSubsystem;
+  private ColorSpinnerCommand colorSpinnerCommand;
+  private ColorTargetCommand colorTargetCommand;
+  private ColorSpinnerDeploy colorSpinnerDeploy;
+  private ColorSpinnerRetract colorSpinnerRetract;
 
-	// Climber Spinner
-	private ClimberSubsystem climberSubsystem;
-	private ClimberUpCommand climberUpCommand;
-	private ClimberDownCommand climberDownCommand;
+  // Climber Spinner
+  private ClimberSubsystem climberSubsystem;
+  private ClimberUpCommand climberUpCommand;
+  private ClimberDownCommand climberDownCommand;
 
-	// Serial connection
-	public ColorSensorSerial colorSensor = new ColorSensorSerial();
-	public ScaleSerial scaleSensor = new ScaleSerial();
-	public GyroscopeSerial gyroscope = new GyroscopeSerial();
-	public BallSensorSerial ballSensor = new BallSensorSerial();
+  // Serial connection
+  public ColorSensorSerial colorSensor = new ColorSensorSerial();
+  public ScaleSerial scaleSensor = new ScaleSerial();
+  public GyroscopeSerial gyroscope = new GyroscopeSerial();
+  public BallSensorSerial ballSensor = new BallSensorSerial();
 
-	// LEDs
-	public LEDSubsystem leds = new LEDSubsystem();
+  // LEDs
+  public LEDSubsystem leds = new LEDSubsystem();
 
-	// controllers
-	public final static XboxController primary = new XboxController(Constants.primary);
-	public final static XboxController secondary = new XboxController(Constants.secondary);
+  // controllers
+  public static final XboxController primary = XboxController.getInstance(Constants.primary);
+  public static final XboxController secondary = XboxController.getInstance(Constants.secondary);
 
-	/**
-	 * The container for the robot. Contains subsystems, OI devices, and commands.
-	 */
-	public RobotContainer() {
-		ArduinoSerialReceiver.initialization(() -> {
-			ballSensor.resetCount();
-		});
-		Config.setup();
-		if(feedEnabled) {
-			feedSubsystem = FeedSubsystem.getInstance();
-			feederCommand = new FeederCommand(feedSubsystem);
-		}
-		if (driveEnabled) {
-			driveSubsystem = DriveSubsystem.getInstance();
-			manualDriveCommand = new ManualDriveCommand(driveSubsystem);
-			brakeCommand = new BrakeCommand(driveSubsystem);
-			boostCommand = new BoostCommand(driveSubsystem);
-			slowCommand = new SlowCommand(driveSubsystem);
-			autoDriveLinear = new AutoDriveLinear(driveSubsystem, gyroscope);
-		}
-		if (limelightEnabled) {
-			limelightSubsystem = LimelightSubsystem.getInstance();
-			if (driveEnabled) {
-				//Vision Testing
-				alignToTarget = new VisionTurn(limelightSubsystem, driveSubsystem);
-				driveToTarget = new VisionDrive(limelightSubsystem, driveSubsystem, 120);
-			}
-		}
-		if (shooterEnabled) {
-			shooterSubsystem = ShooterSubsystem.getInstance();
-			shooterOnCommand = new ShooterOnCommand(shooterSubsystem);
-			shooterOffCommand = new ShooterOffCommand(shooterSubsystem);
-			kickerSubsystem = KickerSubsystem.getInstance();
-			kickerCommand = new KickerCommand(kickerSubsystem, feedSubsystem);
-		}
-		if (shooterHoodEnabled) {
-			shooterHoodSubsystem = ShooterHoodSubsystem.getInstance();
-			hoodManualUpCommand = new HoodManualCommand(shooterHoodSubsystem, true);
-			hoodManualDownCommand = new HoodManualCommand(shooterHoodSubsystem, false);
-			hoodCalibrateCommand = new HoodCalibrateCommand(shooterHoodSubsystem);
-			hoodPIDCommand = new HoodPIDCommand(shooterHoodSubsystem);
-			hoodPresetAngleCommand = new HoodPresetAngleCommand(shooterHoodSubsystem, Constants.hoodPresetAngle);
-			hoodRetractCommand = new HoodRetractCommand(shooterHoodSubsystem, Constants.hoodRetractAngle);
-		}
-		if(chomperEnabled) {
-			chomperSubsystem = ChomperSubsystem.getInstance();
-			chomperCalibrateCommand = new ChomperCalibrateCommand(chomperSubsystem);
-			chomperIntakeCommand = new ChomperIntakeCommand(chomperSubsystem, feedSubsystem);
-			chomperVomitCommand = new ChomperVomitCommand(chomperSubsystem);
-			chomperUpCommand = new ChomperUpPIDCommand(true, chomperSubsystem);
-			chomperDownCommand = new ChomperDownPIDCommand(false, chomperSubsystem);
-			manualchomperUpCommand = new ChomperUpDownCommand(true);
-			manualchomperDownCommand = new ChomperUpDownCommand(false);
-		}
-		if (colorSpinnerEnabled) {
-			colorSpinnerSubsystem = ColorSpinnerSubsystem.getInstance();
-			colorSpinnerCommand = new ColorSpinnerCommand(colorSpinnerSubsystem);
-			colorTargetCommand = new ColorTargetCommand(colorSpinnerSubsystem, colorSensor);
-			colorSpinnerDeploy = new ColorSpinnerDeploy();
-			colorSpinnerRetract = new ColorSpinnerRetract();
-		}
-		if (climberEnabled) {
-			climberSubsystem = ClimberSubsystem.getInstance();
-			climberUpCommand = new ClimberUpCommand(climberSubsystem);
-			climberDownCommand = new ClimberDownCommand(climberSubsystem);
-		}
-		setupBindings();
-		setupCamera(); 
-	}
+  /** The container for the robot. Contains subsystems, OI devices, and commands. */
+  public RobotContainer() {
+    ArduinoSerialReceiver.initialization(
+        () -> {
+          ballSensor.resetCount();
+        });
+    Config.setup();
+    if (feedEnabled) {
+      feedSubsystem = FeedSubsystem.getInstance();
+      feederCommand = new FeederCommand(feedSubsystem);
+    }
+    if (driveEnabled) {
+      driveSubsystem = DriveSubsystem.getInstance();
+      manualDriveCommand = new ManualDriveCommand(driveSubsystem);
+      brakeCommand = new BrakeCommand(driveSubsystem);
+      boostCommand = new BoostCommand(driveSubsystem);
+      slowCommand = new SlowCommand(driveSubsystem);
+      autoDriveLinear = new AutoDriveLinear(driveSubsystem, gyroscope);
+    }
+    if (limelightEnabled) {
+      limelightSubsystem = LimelightSubsystem.getInstance();
+      if (driveEnabled) {
+        // Vision Testing
+        alignToTarget = new VisionTurn(limelightSubsystem, driveSubsystem);
+        driveToTarget = new VisionDrive(limelightSubsystem, driveSubsystem, 120);
+      }
+    }
+    if (shooterEnabled) {
+      shooterSubsystem = ShooterSubsystem.getInstance();
+      shooterOnCommand = new ShooterOnCommand(shooterSubsystem);
+      shooterOffCommand = new ShooterOffCommand(shooterSubsystem);
+      kickerSubsystem = KickerSubsystem.getInstance();
+      kickerCommand = new KickerCommand(kickerSubsystem, feedSubsystem);
+    }
+    if (shooterHoodEnabled) {
+      shooterHoodSubsystem = ShooterHoodSubsystem.getInstance();
+      hoodManualUpCommand = new HoodManualCommand(shooterHoodSubsystem, true);
+      hoodManualDownCommand = new HoodManualCommand(shooterHoodSubsystem, false);
+      hoodCalibrateCommand = new HoodCalibrateCommand(shooterHoodSubsystem);
+      hoodPIDCommand = new HoodPIDCommand(shooterHoodSubsystem);
+      hoodPresetAngleCommand =
+          new HoodPresetAngleCommand(shooterHoodSubsystem, Constants.hoodPresetAngle);
+      hoodRetractCommand = new HoodRetractCommand(shooterHoodSubsystem, Constants.hoodRetractAngle);
+    }
+    if (chomperEnabled) {
+      chomperSubsystem = ChomperSubsystem.getInstance();
+      chomperCalibrateCommand = new ChomperCalibrateCommand(chomperSubsystem);
+      chomperIntakeCommand = new ChomperIntakeCommand(chomperSubsystem, feedSubsystem);
+      chomperVomitCommand = new ChomperVomitCommand(chomperSubsystem);
+      chomperUpCommand = new ChomperUpPIDCommand(true, chomperSubsystem);
+      chomperDownCommand = new ChomperDownPIDCommand(false, chomperSubsystem);
+      manualchomperUpCommand = new ChomperUpDownCommand(true);
+      manualchomperDownCommand = new ChomperUpDownCommand(false);
+    }
+    if (colorSpinnerEnabled) {
+      colorSpinnerSubsystem = ColorSpinnerSubsystem.getInstance();
+      colorSpinnerCommand = new ColorSpinnerCommand(colorSpinnerSubsystem);
+      colorTargetCommand = new ColorTargetCommand(colorSpinnerSubsystem, colorSensor);
+      colorSpinnerDeploy = new ColorSpinnerDeploy();
+      colorSpinnerRetract = new ColorSpinnerRetract();
+    }
+    if (climberEnabled) {
+      climberSubsystem = ClimberSubsystem.getInstance();
+      climberUpCommand = new ClimberUpCommand(climberSubsystem);
+      climberDownCommand = new ClimberDownCommand(climberSubsystem);
+    }
+    setupBindings();
+    setupCamera();
+  }
 
-	public void setupCamera() {
-		UsbCamera cam = CameraServer.getInstance().startAutomaticCapture();
-		cam.setConnectVerbose(0);
-	}
+  public void setupCamera() {
+    UsbCamera cam = CameraServer.getInstance().startAutomaticCapture();
+    cam.setConnectVerbose(0);
+  }
 
-	/**
-	 * Use this method to define your button->command mappings. Buttons can be
-	 * created by instantiating a {@link GenericHID} or one of its subclasses
-	 * ({@link edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then
-	 * passing it to a {@link edu.wpi.first.wpilibj2.command.button.JoystickButton}.
-	 */
-	private void setupBindings() {
-		// primary
-		if (driveEnabled) {
-			primary.buttonB.whileHeld(brakeCommand);
-			primary.buttonBumperRight.whileHeld(boostCommand);
-			primary.buttonBumperLeft.whileHeld(slowCommand);
-			primary.buttonPovLeft.whenPressed(autoDriveLinear);
-		}
-		if (limelightEnabled) {
-			primary.buttonX.whileHeld(alignToTarget);
-			primary.buttonY.whileHeld(driveToTarget);
-		}
-		if (climberEnabled) {
-			climberSubsystem.setStop();
-			primary.buttonPovUp.whileHeld(climberUpCommand);
-			primary.buttonPovDown.whileHeld(climberDownCommand);
-		}
-		if (chomperEnabled) {
-			primary.buttonPovUp.whenPressed(chomperUpCommand);
-			primary.buttonPovDown.whenPressed(chomperDownCommand);
-			primary.buttonMenu.whenPressed(chomperCalibrateCommand);
-			primary.buttonPovRight.whileHeld(manualchomperUpCommand);
-			
-		}
-		// secondary
-		if (shooterEnabled) {
-			secondary.buttonA.whenPressed(shooterOnCommand);
-			secondary.buttonB.whenPressed(shooterOffCommand);
-			secondary.buttonStickLeft.whileHeld(kickerCommand);
-		}
-		if (shooterHoodEnabled) {
-			secondary.buttonMenu.whenPressed(hoodCalibrateCommand);
-			secondary.buttonView.whenPressed(hoodPIDCommand);
-			//secondary.buttonPovUp.whenPressed(hoodPresetAngleCommand);
-			secondary.buttonPovUp.whileHeld(hoodManualUpCommand);
-			secondary.buttonPovDown.whileHeld(hoodManualDownCommand);
-		}
-		if (chomperEnabled) {
-			secondary.buttonBumperLeft.whileHeld(chomperIntakeCommand);
-			secondary.buttonStickRight.whileHeld(chomperVomitCommand);
-			//secondary.buttonBumperRight.whenPressed(chomperCalibrateCommand);
-			//secondary.buttonView.whenPressed(chomperUpCommand);
-			//secondary.buttonMenu.whenPressed(chomperDownCommand);
-			//secondary.buttonA.whileHeld(manualchomperDownCommand);
-			//secondary.buttonB.whileHeld(manualchomperUpCommand);
-			//secondary.buttonX.whileHeld(manualchomperDownCommand);
-			//secondary.buttonY.whileHeld(manualchomperUpCommand);
-		}
-		if (colorSpinnerEnabled) {
-			secondary.buttonPovLeft.whenPressed(colorTargetCommand);
-			secondary.buttonPovUp.whenPressed(colorSpinnerDeploy);
-			secondary.buttonPovDown.whenPressed(colorSpinnerRetract);
-		}
-	}
+  /**
+   * Use this method to define your button->command mappings. Buttons can be created by
+   * instantiating a {@link GenericHID} or one of its subclasses ({@link
+   * edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then passing it to a {@link
+   * edu.wpi.first.wpilibj2.command.button.JoystickButton}.
+   */
+  private void setupBindings() {
+    // primary
+    if (driveEnabled) {
+      primary.buttonB.whileHeld(brakeCommand);
+      primary.buttonBumperRight.whileHeld(boostCommand);
+      primary.buttonBumperLeft.whileHeld(slowCommand);
+      primary.buttonPovLeft.whenPressed(autoDriveLinear);
+    }
+    if (limelightEnabled) {
+      primary.buttonX.whileHeld(alignToTarget);
+      primary.buttonY.whileHeld(driveToTarget);
+    }
+    if (climberEnabled) {
+      climberSubsystem.setStop();
+      primary.buttonPovUp.whileHeld(climberUpCommand);
+      primary.buttonPovDown.whileHeld(climberDownCommand);
+    }
+    if (chomperEnabled) {
+      primary.buttonPovUp.whenPressed(chomperUpCommand);
+      primary.buttonPovDown.whenPressed(chomperDownCommand);
+      primary.buttonMenu.whenPressed(chomperCalibrateCommand);
+      primary.buttonPovRight.whileHeld(manualchomperUpCommand);
+    }
+    // secondary
+    if (shooterEnabled) {
+      secondary.buttonA.whenPressed(shooterOnCommand);
+      secondary.buttonB.whenPressed(shooterOffCommand);
+      secondary.buttonStickLeft.whileHeld(kickerCommand);
+    }
+    if (shooterHoodEnabled) {
+      secondary.buttonMenu.whenPressed(hoodCalibrateCommand);
+      secondary.buttonView.whenPressed(hoodPIDCommand);
+      // secondary.buttonPovUp.whenPressed(hoodPresetAngleCommand);
+      secondary.buttonPovUp.whileHeld(hoodManualUpCommand);
+      secondary.buttonPovDown.whileHeld(hoodManualDownCommand);
+    }
+    if (chomperEnabled) {
+      secondary.buttonBumperLeft.whileHeld(chomperIntakeCommand);
+      secondary.buttonStickRight.whileHeld(chomperVomitCommand);
+      // secondary.buttonBumperRight.whenPressed(chomperCalibrateCommand);
+      // secondary.buttonView.whenPressed(chomperUpCommand);
+      // secondary.buttonMenu.whenPressed(chomperDownCommand);
+      // secondary.buttonA.whileHeld(manualchomperDownCommand);
+      // secondary.buttonB.whileHeld(manualchomperUpCommand);
+      // secondary.buttonX.whileHeld(manualchomperDownCommand);
+      // secondary.buttonY.whileHeld(manualchomperUpCommand);
+    }
+    if (colorSpinnerEnabled) {
+      secondary.buttonPovLeft.whenPressed(colorTargetCommand);
+      secondary.buttonPovUp.whenPressed(colorSpinnerDeploy);
+      secondary.buttonPovDown.whenPressed(colorSpinnerRetract);
+    }
+  }
 
-	public void setDefaultDriveCommand() {
-		if (driveEnabled) {
-			CommandScheduler.getInstance().setDefaultCommand(driveSubsystem, manualDriveCommand);
-		}
-	}
+  public void setDefaultDriveCommand() {
+    if (driveEnabled) {
+      CommandScheduler.getInstance().setDefaultCommand(driveSubsystem, manualDriveCommand);
+    }
+  }
 
-	public void setTeleop() {
-		if (driveEnabled) {
-			manualDriveCommand.schedule();
-			if (limelightEnabled)
-				limelightSubsystem.setLEDStatus(false);
-		}
-	}
+  public void setTeleop() {
+    if (driveEnabled) {
+      manualDriveCommand.schedule();
+      if (limelightEnabled) limelightSubsystem.setLEDStatus(false);
+    }
+  }
 
-	public void setAutonomous() {
-		if (driveEnabled && limelightEnabled) {
-			limelightSubsystem.setLEDStatus(true);
-			alignToTarget.schedule();
-		}
-	}
+  public void setAutonomous() {
+    if (driveEnabled && limelightEnabled) {
+      limelightSubsystem.setLEDStatus(true);
+      alignToTarget.schedule();
+    }
+  }
 
-	public void setDisabled() {
-		if (limelightEnabled)
-			limelightSubsystem.setLEDStatus(false);
-	}
-
+  public void setDisabled() {
+    if (limelightEnabled) limelightSubsystem.setLEDStatus(false);
+  }
 }

--- a/src/main/java/com/chargerrobotics/utils/XboxController.java
+++ b/src/main/java/com/chargerrobotics/utils/XboxController.java
@@ -2,7 +2,6 @@ package com.chargerrobotics.utils;
 
 import com.chargerrobotics.utils.XboxPovButton.POVDirection;
 import com.google.common.annotations.VisibleForTesting;
-
 import edu.wpi.first.wpilibj.GenericHID.Hand;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 import java.util.HashMap;
@@ -67,8 +66,8 @@ public class XboxController {
   }
 
   /**
-   * Get instance of the controller with specified ID and use provided
-   * factory to create a controller. This is intended for testing purposes
+   * Get instance of the controller with specified ID and use provided factory to create a
+   * controller. This is intended for testing purposes
    *
    * @param id The ID of the controller to get
    * @param WpiLibXboxControllerFactory A factory to create the internal controller to use

--- a/src/main/java/com/chargerrobotics/utils/XboxController.java
+++ b/src/main/java/com/chargerrobotics/utils/XboxController.java
@@ -1,127 +1,161 @@
 package com.chargerrobotics.utils;
 
-import java.util.HashMap;
-
-import com.chargerrobotics.utils.XboxPovButton;
 import com.chargerrobotics.utils.XboxPovButton.POVDirection;
+import com.google.common.annotations.VisibleForTesting;
 
 import edu.wpi.first.wpilibj.GenericHID.Hand;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
+import java.util.HashMap;
 
 public class XboxController {
 
-	private static final HashMap<Integer, XboxController> instances = new HashMap<Integer, XboxController>();
+  public interface WpiLibXboxControllerFactory {
+    public edu.wpi.first.wpilibj.XboxController getController(int id);
+  }
 
-	edu.wpi.first.wpilibj.XboxController controller;
+  private static final HashMap<Integer, XboxController> instances =
+      new HashMap<Integer, XboxController>();
 
-	public JoystickButton buttonA;
-	public JoystickButton buttonB;
-	public JoystickButton buttonX;
-	public JoystickButton buttonY;
-	public JoystickButton buttonBumperLeft;
-	public JoystickButton buttonBumperRight;
-	public JoystickButton buttonView;
-	public JoystickButton buttonMenu;
-	public JoystickButton buttonStickLeft;
-	public JoystickButton buttonStickRight;
-	public XboxPovButton buttonPovUp;
-	public XboxPovButton buttonPovRight;
-	public XboxPovButton buttonPovDown;
-	public XboxPovButton buttonPovLeft;
+  edu.wpi.first.wpilibj.XboxController controller;
 
-	private static final double deadzone = 0.13;
+  public JoystickButton buttonA;
+  public JoystickButton buttonB;
+  public JoystickButton buttonX;
+  public JoystickButton buttonY;
+  public JoystickButton buttonBumperLeft;
+  public JoystickButton buttonBumperRight;
+  public JoystickButton buttonView;
+  public JoystickButton buttonMenu;
+  public JoystickButton buttonStickLeft;
+  public JoystickButton buttonStickRight;
+  public XboxPovButton buttonPovUp;
+  public XboxPovButton buttonPovRight;
+  public XboxPovButton buttonPovDown;
+  public XboxPovButton buttonPovLeft;
 
-	public XboxController() {
-		this(0);
-	}
+  private static final double deadzone = 0.13;
 
-	public XboxController(int id) {
-		controller = new edu.wpi.first.wpilibj.XboxController(id);
-		setupButtons();
-		instances.put(id, this);
-	}
+  private XboxController(edu.wpi.first.wpilibj.XboxController controller) {
+    this.controller = controller;
+    setupButtons();
+  }
 
-	public static XboxController getInstance(int id) {
-		return instances.get(id);
-	}
+  /**
+   * Convenience method for getting controller ID 0
+   *
+   * @return Controller with ID 0
+   */
+  public static XboxController getInstance() {
+    return getInstance(0);
+  }
 
-	private void setupButtons() {
-		buttonA = new JoystickButton(controller, XboxControllerButton.A.getId());
-		buttonB = new JoystickButton(controller, XboxControllerButton.B.getId());
-		buttonX = new JoystickButton(controller, XboxControllerButton.X.getId());
-		buttonY = new JoystickButton(controller, XboxControllerButton.Y.getId());
-		buttonBumperLeft = new JoystickButton(controller, XboxControllerButton.BUMPER_LEFT.getId());
-		buttonBumperRight = new JoystickButton(controller, XboxControllerButton.BUMPER_RIGHT.getId());
-		buttonView = new JoystickButton(controller, XboxControllerButton.VIEW.getId());
-		buttonMenu = new JoystickButton(controller, XboxControllerButton.MENU.getId());
-		buttonStickLeft = new JoystickButton(controller, XboxControllerButton.STICK_LEFT.getId());
-		buttonStickRight = new JoystickButton(controller, XboxControllerButton.STICK_RIGHT.getId());
-		buttonPovUp = new XboxPovButton(controller, POVDirection.UP);
-		buttonPovRight = new XboxPovButton(controller, POVDirection.RIGHT);
-		buttonPovDown = new XboxPovButton(controller, POVDirection.DOWN);
-		buttonPovLeft = new XboxPovButton(controller, POVDirection.LEFT);
-	}
+  /**
+   * Get instance of the controller with specified ID
+   *
+   * @param id The ID of the controller to get
+   * @return Controller with the given ID
+   */
+  public static XboxController getInstance(int id) {
+    return getInstance(
+        id,
+        new WpiLibXboxControllerFactory() {
+          @Override
+          public edu.wpi.first.wpilibj.XboxController getController(int id) {
+            return new edu.wpi.first.wpilibj.XboxController(id);
+          }
+        });
+  }
 
-	public double getLeftStickX() {
-		double n = controller.getX(Hand.kLeft);
-		if (Math.abs(n) <= deadzone)
-			return 0.0;
-		else {
-			double c = (Math.abs(n) - deadzone) / (1.0 - deadzone);
-			return (n > 0) ? c : -c;
-		}
-	}
+  /**
+   * Get instance of the controller with specified ID and use provided
+   * factory to create a controller. This is intended for testing purposes
+   *
+   * @param id The ID of the controller to get
+   * @param WpiLibXboxControllerFactory A factory to create the internal controller to use
+   * @return Controller with the given ID
+   */
+  @VisibleForTesting
+  public static XboxController getInstance(int id, WpiLibXboxControllerFactory controllerFactory) {
+    XboxController inst = instances.get(id);
+    if (inst == null) {
+      instances.put(id, new XboxController(controllerFactory.getController(id)));
+    }
+    return instances.get(id);
+  }
 
-	public double getLeftStickY() {
-		double n = controller.getY(Hand.kLeft);
-		if (Math.abs(n) <= deadzone)
-			return 0.0;
-		else {
-			double c = (Math.abs(n) - deadzone) / (1.0 - deadzone);
-			return (n > 0) ? c : -c;
-		}
-	}
+  private void setupButtons() {
+    buttonA = new JoystickButton(controller, XboxControllerButton.A.getId());
+    buttonB = new JoystickButton(controller, XboxControllerButton.B.getId());
+    buttonX = new JoystickButton(controller, XboxControllerButton.X.getId());
+    buttonY = new JoystickButton(controller, XboxControllerButton.Y.getId());
+    buttonBumperLeft = new JoystickButton(controller, XboxControllerButton.BUMPER_LEFT.getId());
+    buttonBumperRight = new JoystickButton(controller, XboxControllerButton.BUMPER_RIGHT.getId());
+    buttonView = new JoystickButton(controller, XboxControllerButton.VIEW.getId());
+    buttonMenu = new JoystickButton(controller, XboxControllerButton.MENU.getId());
+    buttonStickLeft = new JoystickButton(controller, XboxControllerButton.STICK_LEFT.getId());
+    buttonStickRight = new JoystickButton(controller, XboxControllerButton.STICK_RIGHT.getId());
+    buttonPovUp = new XboxPovButton(controller, POVDirection.UP);
+    buttonPovRight = new XboxPovButton(controller, POVDirection.RIGHT);
+    buttonPovDown = new XboxPovButton(controller, POVDirection.DOWN);
+    buttonPovLeft = new XboxPovButton(controller, POVDirection.LEFT);
+  }
 
-	public double getRightStickX() {
-		double n = controller.getX(Hand.kRight);
-		if (Math.abs(n) <= deadzone)
-			return 0.0;
-		else {
-			double c = (Math.abs(n) - deadzone) / (1.0 - deadzone);
-			return (n > 0) ? c : -c;
-		}
-	}
+  private double correctForDeadzone(double raw) {
+    if (Math.abs(raw) <= deadzone) return 0.0;
+    else {
+      double c = (Math.abs(raw) - deadzone) / (1.0 - deadzone);
+      return (raw > 0) ? c : -c;
+    }
+  }
 
-	public double getRightStickY() {
-		double n = controller.getY(Hand.kRight);
-		if (Math.abs(n) <= deadzone)
-			return 0.0;
-		else {
-			double c = (Math.abs(n) - deadzone) / (1.0 - deadzone);
-			return (n > 0) ? c : -c;
-		}
-	}
+  public double getLeftStickX() {
+    double n = controller.getX(Hand.kLeft);
+    return correctForDeadzone(n);
+  }
 
-	public double getLeftTrigger() {
-		return controller.getTriggerAxis(Hand.kLeft);
-	}
+  public double getLeftStickY() {
+    double n = controller.getY(Hand.kLeft);
+    return correctForDeadzone(n);
+  }
 
-	public double getRightTrigger() {
-		return controller.getTriggerAxis(Hand.kRight);
-	}
+  public double getRightStickX() {
+    double n = controller.getX(Hand.kRight);
+    return correctForDeadzone(n);
+  }
 
-	public enum XboxControllerButton {
-		A(1), B(2), X(3), Y(4), BUMPER_LEFT(5), BUMPER_RIGHT(6), VIEW(7), MENU(8), STICK_LEFT(9), STICK_RIGHT(10);
+  public double getRightStickY() {
+    double n = controller.getY(Hand.kRight);
+    return correctForDeadzone(n);
+  }
 
-		private final int id;
+  public double getLeftTrigger() {
+    return controller.getTriggerAxis(Hand.kLeft);
+  }
 
-		XboxControllerButton(int id) {
-			this.id = id;
-		}
+  public double getRightTrigger() {
+    return controller.getTriggerAxis(Hand.kRight);
+  }
 
-		public int getId() {
-			return id;
-		}
-	}
+  public enum XboxControllerButton {
+    A(1),
+    B(2),
+    X(3),
+    Y(4),
+    BUMPER_LEFT(5),
+    BUMPER_RIGHT(6),
+    VIEW(7),
+    MENU(8),
+    STICK_LEFT(9),
+    STICK_RIGHT(10);
 
+    private final int id;
+
+    XboxControllerButton(int id) {
+      this.id = id;
+    }
+
+    public int getId() {
+      return id;
+    }
+  }
 }

--- a/src/test/java/com/chargerrobotics/utils/UT_XBoxController.java
+++ b/src/test/java/com/chargerrobotics/utils/UT_XBoxController.java
@@ -1,15 +1,17 @@
 package com.chargerrobotics.utils;
 
-// Import testing libraries
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
 import com.chargerrobotics.utils.XboxController.WpiLibXboxControllerFactory;
 import edu.wpi.first.wpilibj.GenericHID.Hand;
-import org.testng.annotations.*;
-
-// Import the unit under test
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 public class UT_XBoxController {
 
@@ -64,8 +66,6 @@ public class UT_XBoxController {
     }
 
     assertNotEquals(joystickReading, 2.0, "Joystick reading not set!");
-    System.out.println(
-        "Testing " + value + ", " + hand + " : " + expectedValue + " == " + joystickReading);
     assertEquals(joystickReading, expectedValue, joystickAcceptableError);
   }
 
@@ -92,6 +92,7 @@ public class UT_XBoxController {
         break;
     }
 
+    assertNotEquals(joystickReading, 2.0, "Joystick reading not set!");
     assertEquals(joystickReading, expectedValue, joystickAcceptableError);
   }
 

--- a/src/test/java/com/chargerrobotics/utils/UT_XBoxController.java
+++ b/src/test/java/com/chargerrobotics/utils/UT_XBoxController.java
@@ -1,0 +1,167 @@
+package com.chargerrobotics.utils;
+
+// Import testing libraries
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.assertEquals;
+
+import edu.wpi.first.wpilibj.GenericHID.Hand;
+import org.testng.annotations.*;
+
+// Import the unit under test
+
+public class UT_XBoxController {
+
+  private com.chargerrobotics.utils.XboxController controller;
+
+  private edu.wpi.first.wpilibj.XboxController internalController;
+
+  @BeforeClass
+  public void setUp() {
+    // Init unit under test
+    controller = new com.chargerrobotics.utils.XboxController();
+
+    internalController = spy(controller.controller);
+  }
+
+  /**
+   * Tests that when a particular X value is returned from the controller
+   * that the deadzone is triggered, resulting in a 0.0 reading
+   *
+   * @param value The value returned by the physical controller
+   * @param hand The stick (left or right) to test against
+   */
+  @Test(dataProvider = "deadzoneValuesProvider")
+  public void testStickXDeadzone(double value, Hand hand) {
+    when(internalController.getX(hand)).thenReturn(value);
+
+    double joystickReading = 2.0; // Utilize 2.0 as an invalid value as it is out of the joystick range
+    switch (hand) {
+      case kLeft:
+        joystickReading = controller.getLeftStickX();
+      case kRight:
+        joystickReading = controller.getRightStickX();
+    }
+
+    assertEquals(joystickReading, 0.0);
+  }
+
+  /**
+   * Tests that when a particular Y value is returned from the controller
+   * that the deadzone is triggered, resulting in a 0.0 reading
+   *
+   * @param value The value returned by the physical controller
+   * @param hand The stick (left or right) to test against
+   */
+  @Test(dataProvider = "deadzoneValuesProvider")
+  public void testStickYDeadzone(double value, Hand hand) {
+    when(internalController.getY(hand)).thenReturn(value);
+
+    double joystickReading = 2.0; // Utilize 2.0 as an invalid value as it is out of the joystick range
+    switch (hand) {
+      case kLeft:
+        joystickReading = controller.getLeftStickY();
+      case kRight:
+        joystickReading = controller.getRightStickY();
+    }
+
+    assertEquals(joystickReading, 0.0);
+  }
+
+  /**
+   * Tests that when a particular X value is returned from the controller
+   * that the deadzone is not triggered
+   *
+   * @param value The value returned by the physical controller
+   * @param hand The stick (left or right) to test against
+   */
+  @Test(dataProvider = "nonDeadzoneValuesProvider")
+  public void testStickXNoDeadzone(double value, Hand hand) {
+    when(internalController.getX(hand)).thenReturn(value);
+
+    assertEquals(controller.getLeftStickX(), value);
+
+    double joystickReading = 2.0; // Utilize 2.0 as an invalid value as it is out of the joystick range
+    switch (hand) {
+      case kLeft:
+        joystickReading = controller.getLeftStickX();
+      case kRight:
+        joystickReading = controller.getRightStickX();
+    }
+
+    assertEquals(joystickReading, value);
+  }
+
+  /**
+   * Tests that when a particular Y value is returned from the controller
+   * that the deadzone is not triggered
+   *
+   * @param value The value returned by the physical controller
+   * @param hand The stick (left or right) to test against
+   */
+  @Test(dataProvider = "nonDeadzoneValuesProvider")
+  public void testStickYNoDeadzone(double value, Hand hand) {
+    when(internalController.getY(hand)).thenReturn(value);
+
+    double joystickReading = 2.0; // Utilize 2.0 as an invalid value as it is out of the joystick range
+    switch (hand) {
+      case kLeft:
+        joystickReading = controller.getLeftStickY();
+      case kRight:
+        joystickReading = controller.getRightStickY();
+    }
+
+    assertEquals(joystickReading, value);
+  }
+
+  @DataProvider
+  public Object[][] deadzoneValuesProvider() {
+    return new Object[][] {
+      {0.0, Hand.kLeft},
+      {0.0, Hand.kRight},
+      {0.05, Hand.kLeft},
+      {0.05, Hand.kRight},
+      {0.10, Hand.kLeft},
+      {0.10, Hand.kRight},
+      {0.13, Hand.kLeft},
+      {0.13, Hand.kRight},
+      {0.111111111111, Hand.kLeft},
+      {0.111111111111, Hand.kRight},
+      {-0.0, Hand.kLeft},
+      {-0.0, Hand.kRight},
+      {-0.05, Hand.kLeft},
+      {-0.05, Hand.kRight},
+      {-0.10, Hand.kLeft},
+      {-0.10, Hand.kRight},
+      {-0.13, Hand.kLeft},
+      {-0.13, Hand.kRight},
+      {-0.111111111111, Hand.kLeft},
+      {-0.111111111111, Hand.kRight},
+    };
+  }
+
+  @DataProvider
+  public Object[][] nonDeadzoneValuesProvider() {
+    return new Object[][] {
+      {1.0, Hand.kLeft},
+      {1.0, Hand.kRight},
+      {0.5, Hand.kLeft},
+      {0.5, Hand.kRight},
+      {0.25, Hand.kLeft},
+      {0.25, Hand.kRight},
+      {0.2, Hand.kLeft},
+      {0.2, Hand.kRight},
+      {0.13000000001, Hand.kLeft},
+      {0.13000000001, Hand.kRight},
+      {-1.0, Hand.kLeft},
+      {-1.0, Hand.kRight},
+      {-0.5, Hand.kLeft},
+      {-0.5, Hand.kRight},
+      {-0.25, Hand.kLeft},
+      {-0.25, Hand.kRight},
+      {-0.2, Hand.kLeft},
+      {-0.2, Hand.kRight},
+      {-0.13000000001, Hand.kLeft},
+      {-0.13000000001, Hand.kRight},
+    };
+  }
+}

--- a/src/test/java/com/chargerrobotics/utils/UT_XBoxController.java
+++ b/src/test/java/com/chargerrobotics/utils/UT_XBoxController.java
@@ -3,7 +3,9 @@ package com.chargerrobotics.utils;
 // Import testing libraries
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
+import com.chargerrobotics.utils.XboxController.WpiLibXboxControllerFactory;
 import edu.wpi.first.wpilibj.GenericHID.Hand;
 import org.testng.annotations.*;
 
@@ -11,157 +13,131 @@ import org.testng.annotations.*;
 
 public class UT_XBoxController {
 
-  private com.chargerrobotics.utils.XboxController controller;
+  private static final double joystickAcceptableError = 0.000001;
 
-  private edu.wpi.first.wpilibj.XboxController internalController;
+  private com.chargerrobotics.utils.XboxController controllerSpy;
+
+  private edu.wpi.first.wpilibj.XboxController internalControllerMock;
 
   @BeforeClass
   public void setUp() {
     // Init unit under test
-    controller = new com.chargerrobotics.utils.XboxController();
+    internalControllerMock = mock(edu.wpi.first.wpilibj.XboxController.class);
 
-    internalController = spy(controller.controller);
+    // Provide a controller factory so that the singleton uses the mocked controller
+    controllerSpy =
+        spy(
+            XboxController.getInstance(
+                0,
+                new WpiLibXboxControllerFactory() {
+                  @Override
+                  public edu.wpi.first.wpilibj.XboxController getController(int id) {
+                    return internalControllerMock;
+                  }
+                }));
   }
 
   /**
-   * Tests that when a particular X value is returned from the controller
-   * that the deadzone is triggered, resulting in a 0.0 reading
+   * Tests that when a particular X value is returned from the controller that the expected reading
+   * is provided
    *
    * @param value The value returned by the physical controller
    * @param hand The stick (left or right) to test against
+   * @param expectedValue The value that should be returned by as the reading
    */
-  @Test(dataProvider = "deadzoneValuesProvider")
-  public void testStickXDeadzone(double value, Hand hand) {
-    when(internalController.getX(hand)).thenReturn(value);
+  @Test(dataProvider = "joystickResultsProvider")
+  public void testStickX(double value, Hand hand, double expectedValue) {
+    // Reset mock to ensure valid data
+    reset(internalControllerMock);
+    when(internalControllerMock.getX(hand)).thenReturn(value);
 
-    double joystickReading = 2.0; // Utilize 2.0 as an invalid value as it is out of the joystick range
+    double joystickReading =
+        2.0; // Utilize 2.0 as an invalid value as it is out of the joystick range
+
     switch (hand) {
       case kLeft:
-        joystickReading = controller.getLeftStickX();
+        joystickReading = controllerSpy.getLeftStickX();
+        break;
       case kRight:
-        joystickReading = controller.getRightStickX();
+        joystickReading = controllerSpy.getRightStickX();
+        break;
     }
 
-    assertEquals(joystickReading, 0.0);
+    assertNotEquals(joystickReading, 2.0, "Joystick reading not set!");
+    System.out.println(
+        "Testing " + value + ", " + hand + " : " + expectedValue + " == " + joystickReading);
+    assertEquals(joystickReading, expectedValue, joystickAcceptableError);
   }
 
   /**
-   * Tests that when a particular Y value is returned from the controller
-   * that the deadzone is triggered, resulting in a 0.0 reading
+   * Tests that when a particular Y value is returned from the controller that the expected reading
+   * is provided
    *
    * @param value The value returned by the physical controller
    * @param hand The stick (left or right) to test against
+   * @param expectedValue The value that should be returned by as the reading
    */
-  @Test(dataProvider = "deadzoneValuesProvider")
-  public void testStickYDeadzone(double value, Hand hand) {
-    when(internalController.getY(hand)).thenReturn(value);
+  @Test(dataProvider = "joystickResultsProvider")
+  public void testStickY(double value, Hand hand, double expectedValue) {
+    when(internalControllerMock.getY(hand)).thenReturn(value);
 
-    double joystickReading = 2.0; // Utilize 2.0 as an invalid value as it is out of the joystick range
+    double joystickReading =
+        2.0; // Utilize 2.0 as an invalid value as it is out of the joystick range
     switch (hand) {
       case kLeft:
-        joystickReading = controller.getLeftStickY();
+        joystickReading = controllerSpy.getLeftStickY();
+        break;
       case kRight:
-        joystickReading = controller.getRightStickY();
+        joystickReading = controllerSpy.getRightStickY();
+        break;
     }
 
-    assertEquals(joystickReading, 0.0);
-  }
-
-  /**
-   * Tests that when a particular X value is returned from the controller
-   * that the deadzone is not triggered
-   *
-   * @param value The value returned by the physical controller
-   * @param hand The stick (left or right) to test against
-   */
-  @Test(dataProvider = "nonDeadzoneValuesProvider")
-  public void testStickXNoDeadzone(double value, Hand hand) {
-    when(internalController.getX(hand)).thenReturn(value);
-
-    assertEquals(controller.getLeftStickX(), value);
-
-    double joystickReading = 2.0; // Utilize 2.0 as an invalid value as it is out of the joystick range
-    switch (hand) {
-      case kLeft:
-        joystickReading = controller.getLeftStickX();
-      case kRight:
-        joystickReading = controller.getRightStickX();
-    }
-
-    assertEquals(joystickReading, value);
-  }
-
-  /**
-   * Tests that when a particular Y value is returned from the controller
-   * that the deadzone is not triggered
-   *
-   * @param value The value returned by the physical controller
-   * @param hand The stick (left or right) to test against
-   */
-  @Test(dataProvider = "nonDeadzoneValuesProvider")
-  public void testStickYNoDeadzone(double value, Hand hand) {
-    when(internalController.getY(hand)).thenReturn(value);
-
-    double joystickReading = 2.0; // Utilize 2.0 as an invalid value as it is out of the joystick range
-    switch (hand) {
-      case kLeft:
-        joystickReading = controller.getLeftStickY();
-      case kRight:
-        joystickReading = controller.getRightStickY();
-    }
-
-    assertEquals(joystickReading, value);
+    assertEquals(joystickReading, expectedValue, joystickAcceptableError);
   }
 
   @DataProvider
-  public Object[][] deadzoneValuesProvider() {
+  public Object[][] joystickResultsProvider() {
     return new Object[][] {
-      {0.0, Hand.kLeft},
-      {0.0, Hand.kRight},
-      {0.05, Hand.kLeft},
-      {0.05, Hand.kRight},
-      {0.10, Hand.kLeft},
-      {0.10, Hand.kRight},
-      {0.13, Hand.kLeft},
-      {0.13, Hand.kRight},
-      {0.111111111111, Hand.kLeft},
-      {0.111111111111, Hand.kRight},
-      {-0.0, Hand.kLeft},
-      {-0.0, Hand.kRight},
-      {-0.05, Hand.kLeft},
-      {-0.05, Hand.kRight},
-      {-0.10, Hand.kLeft},
-      {-0.10, Hand.kRight},
-      {-0.13, Hand.kLeft},
-      {-0.13, Hand.kRight},
-      {-0.111111111111, Hand.kLeft},
-      {-0.111111111111, Hand.kRight},
-    };
-  }
-
-  @DataProvider
-  public Object[][] nonDeadzoneValuesProvider() {
-    return new Object[][] {
-      {1.0, Hand.kLeft},
-      {1.0, Hand.kRight},
-      {0.5, Hand.kLeft},
-      {0.5, Hand.kRight},
-      {0.25, Hand.kLeft},
-      {0.25, Hand.kRight},
-      {0.2, Hand.kLeft},
-      {0.2, Hand.kRight},
-      {0.13000000001, Hand.kLeft},
-      {0.13000000001, Hand.kRight},
-      {-1.0, Hand.kLeft},
-      {-1.0, Hand.kRight},
-      {-0.5, Hand.kLeft},
-      {-0.5, Hand.kRight},
-      {-0.25, Hand.kLeft},
-      {-0.25, Hand.kRight},
-      {-0.2, Hand.kLeft},
-      {-0.2, Hand.kRight},
-      {-0.13000000001, Hand.kLeft},
-      {-0.13000000001, Hand.kRight},
+      {0.0, Hand.kLeft, 0.0},
+      {0.0, Hand.kRight, 0.0},
+      {0.05, Hand.kLeft, 0.0},
+      {0.05, Hand.kRight, 0.0},
+      {0.10, Hand.kLeft, 0.0},
+      {0.10, Hand.kRight, 0.0},
+      {0.13, Hand.kLeft, 0.0},
+      {0.13, Hand.kRight, 0.0},
+      {0.111111111111, Hand.kLeft, 0.0},
+      {0.111111111111, Hand.kRight, 0.0},
+      {-0.0, Hand.kLeft, 0.0},
+      {-0.0, Hand.kRight, 0.0},
+      {-0.05, Hand.kLeft, 0.0},
+      {-0.05, Hand.kRight, 0.0},
+      {-0.10, Hand.kLeft, 0.0},
+      {-0.10, Hand.kRight, 0.0},
+      {-0.13, Hand.kLeft, 0.0},
+      {-0.13, Hand.kRight, 0.0},
+      {-0.111111111111, Hand.kLeft, 0.0},
+      {-0.111111111111, Hand.kRight, 0.0},
+      {1.0, Hand.kLeft, 1.0},
+      {1.0, Hand.kRight, 1.0},
+      {0.5, Hand.kLeft, 0.425287},
+      {0.5, Hand.kRight, 0.425287},
+      {0.25, Hand.kLeft, 0.137931},
+      {0.25, Hand.kRight, 0.137931},
+      {0.2, Hand.kLeft, 0.080460},
+      {0.2, Hand.kRight, 0.080460},
+      {0.13000000001, Hand.kLeft, 0.00000000001},
+      {0.13000000001, Hand.kRight, 0.00000000001},
+      {-1.0, Hand.kLeft, -1.0},
+      {-1.0, Hand.kRight, -1.0},
+      {-0.5, Hand.kLeft, -0.425287},
+      {-0.5, Hand.kRight, -0.425287},
+      {-0.25, Hand.kLeft, -0.137931},
+      {-0.25, Hand.kRight, -0.137931},
+      {-0.2, Hand.kLeft, -0.080460},
+      {-0.2, Hand.kRight, -0.080460},
+      {-0.13000000001, Hand.kLeft, -0.00000000001},
+      {-0.13000000001, Hand.kRight, -0.00000000001},
     };
   }
 }


### PR DESCRIPTION
This PR introduces the necessary changes to `build.gradle` and other files to support unit testing.
The testing framework utilized is TestNG with mocking from Mockito.

Running tests can be performed via the `test` Gradle task or via in code VSCode buttons (modifications to `settings.json` are required for VSCode tests to get necessary dependencies, though the Gradle tests will still run without them). The `Java Test Runner` extension is added as a recommended extension (via `extensions.json`) for ease of use.

The tests have also been added to the GitHub Action which performs build and lint checks during pushes to and pull requests targetted at `master`.

Provided is a sample unit test for the `XboxController` class:
- `XboxController.java` is modified to be a true Singleton and allow for testability (accepting a Factory to create the internal controller such that it can be mocked)
- Some minor refactoring to `XboxController.java` to reduce code repetition.
- `RobotContainer.java` is modified to use the new Singleton form of `XboxController.java` (other changes are just linting)
- Test currently covers the deadzone calculations for left and right joysticks.

Future Work:
- Provide a sample for how to do functional testing with the FRC simulator (presuming this is feasible).
- Configure Gradle to run unit tests or functional tests separately if requested.

One known limitation:
Due to a known bug with the VSCode `Java Test Runner` extension, tests using the TestNG `DataProvider` (as is done with this example) don't show as failed unless the final data point fails. The tests will still fail properly with Gradle, thus this does not affect any of the automated checks.