### PR TITLE
Update WpiLib to 2021.2.1 as per Team Update 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2021.1.2"
+    id "edu.wpi.first.GradleRIO" version "2021.2.1"
     id "com.diffplug.spotless" version "5.9.0"
 }
 


### PR DESCRIPTION
Team Update 5 noted that the 2021.2.1 version of WpiLib had been released. This modifies the `build.gradle` file to bring the repo up to date. A build _should_ be all that is needed for everyone to get the latest fixes.

[Team Update 5](https://firstfrc.blob.core.windows.net/frc2021/Manual/TeamUpdates/2021TeamUpdate05.pdf)

[2021.2.1 release notes](https://github.com/wpilibsuite/allwpilib/releases/tag/v2021.2.1)