### PR TITLE
Add drivetrain simulator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ deploy {
 }
 
 // Set this to true to enable desktop support.
-def includeDesktopSupport = false
+def includeDesktopSupport = true
 
 repositories {
     maven { url 'https://jitpack.io' }

--- a/src/main/java/com/chargerrobotics/Constants.java
+++ b/src/main/java/com/chargerrobotics/Constants.java
@@ -8,102 +8,116 @@
 package com.chargerrobotics;
 
 /**
- * The Constants class provides a convenient place for teams to hold robot-wide
- * numerical or boolean constants. This class should not be used for any other
- * purpose. All constants should be declared globally (i.e. public static). Do
- * not put anything functional in this class.
+ * The Constants class provides a convenient place for teams to hold robot-wide numerical or boolean
+ * constants. This class should not be used for any other purpose. All constants should be declared
+ * globally (i.e. public static). Do not put anything functional in this class.
  *
- * <p>
- * It is advised to statically import this class (or one of its inner classes)
- * wherever the constants are needed, to reduce verbosity.
+ * <p>It is advised to statically import this class (or one of its inner classes) wherever the
+ * constants are needed, to reduce verbosity.
  */
 public final class Constants {
-	// Controller IDs
-	public static final int primary = 0;
-	public static final int secondary = 1;
+  // Controller IDs
+  public static final int primary = 0;
+  public static final int secondary = 1;
 
-	// CAN Id's
-	// 1: Power distribution panel (PDP)
-	// 2: Pneumatic Control Module (PCM)
-	// 1x: Drive: Odds are left, evens are right
-	// 2x: Shooter
-	// 3x: Color Spinner
-	public static final int powerDistributionPanel = 1;
-	public static final int rightFrontDrive = 11;
-	public static final int rightRearDrive = 12;
-	public static final int leftRearDrive = 13;
-	public static final int leftFrontDrive = 14;
-	public static final int shooterLeft = 21;
-	public static final int shooterRight = 22;
-	public static final int shooterHood = 23;
-	public static final int colorSpinner = 31;
-	public static final int chomperFeed = 41;
-	public static final int chomperLift = 42;
-  	public static final int feedStage = 43;
-	public static final int kicker = 44;
-	public static final int climbExtender = 51;
-	public static final int climbPush2 = 52;
-	public static final int climbPull = 53;
+  // CAN Id's
+  // 1: Power distribution panel (PDP)
+  // 2: Pneumatic Control Module (PCM)
+  // 1x: Drive: Odds are left, evens are right
+  // 2x: Shooter
+  // 3x: Color Spinner
+  public static final int powerDistributionPanel = 1;
+  public static final int rightFrontDrive = 11;
+  public static final int rightRearDrive = 12;
+  public static final int leftRearDrive = 13;
+  public static final int leftFrontDrive = 14;
+  public static final int shooterLeft = 21;
+  public static final int shooterRight = 22;
+  public static final int shooterHood = 23;
+  public static final int colorSpinner = 31;
+  public static final int chomperFeed = 41;
+  public static final int chomperLift = 42;
+  public static final int feedStage = 43;
+  public static final int kicker = 44;
+  public static final int climbExtender = 51;
+  public static final int climbPush2 = 52;
+  public static final int climbPull = 53;
 
-	//PWM IDs
-	public static final int colorSpinnerLifter = 9;
-	public static final int leds = 1;
+  // PWM IDs
+  public static final int colorSpinnerLifter = 9;
+  public static final int leds = 1;
 
-	//Digital In/Out Ports
-	public static final int chomperLimitSwitch = 9;
-	public static final int hoodLimitSwitch = 1;
+  // Digital In/Out Ports
+  public static final int chomperLimitSwitch = 9;
+  public static final int hoodLimitSwitch = 1;
 
-	//Chomper Constants
-	public static final int chomperDistToDown = 550;
-	public static final int chomperDistBottomToUp = 1999;
+  // Chomper Constants
+  public static final int chomperDistToDown = 550;
+  public static final int chomperDistBottomToUp = 1999;
 
-	// Shooter Constants
-	public static final double shooterTargetRPM = 2500.0;
-	public static final double shooterP = 0.0005;
-	public static final double shooterI = 0.00000047;
-	public static final double shooterD = 0.014;
-	public static final int shooterCurrentLimit = 40;
-	public static final double shooterFeedForward = 0.0;
-	public static final double shooterStaticGain = 0.0;
-	public static final double shooterVelocityGain = 0.0;
-	public static final double shooterMinOutput = -1.0;
-	public static final double shooterMaxOutput = 1.0;
-	
-	public static final double desiredDistance = 120.0;
+  // Shooter Constants
+  public static final double shooterTargetRPM = 2500.0;
+  public static final double shooterP = 0.0005;
+  public static final double shooterI = 0.00000047;
+  public static final double shooterD = 0.014;
+  public static final int shooterCurrentLimit = 40;
+  public static final double shooterFeedForward = 0.0;
+  public static final double shooterStaticGain = 0.0;
+  public static final double shooterVelocityGain = 0.0;
+  public static final double shooterMinOutput = -1.0;
+  public static final double shooterMaxOutput = 1.0;
 
-	// Shooter Hood Constants
-	public static final int hoodPIDLoopId = 0;
-	public static final int hoodGainSlot = 0;
-	public static final int hoodTimeOutMs = 30;
-	public static final int ticksPerRev = 0;
-	public static final double hoodP = 0.0007;
-	public static final double hoodI = 0.00038;
-	public static final double hoodD = 0.0;
-	public static final double hoodF = 0.0;
+  public static final double desiredDistance = 120.0;
 
-	public static final double hoodPresetAngle = 500;
-	public static final double hoodRetractAngle = 1800;
-	public static final double defaultHoodSpeed = 0.30;
+  // Shooter Hood Constants
+  public static final int hoodPIDLoopId = 0;
+  public static final int hoodGainSlot = 0;
+  public static final int hoodTimeOutMs = 30;
+  public static final int ticksPerRev = 0;
+  public static final double hoodP = 0.0007;
+  public static final double hoodI = 0.00038;
+  public static final double hoodD = 0.0;
+  public static final double hoodF = 0.0;
 
+  public static final double hoodPresetAngle = 500;
+  public static final double hoodRetractAngle = 1800;
+  public static final double defaultHoodSpeed = 0.30;
 
-	// File Names
-	public static final String dataStoragePath = "/home/lvuser";
-	public static final String configFileName = "config.yml";
+  // Autonomous Drive Constants
+  public static final double driveGearRatio =
+      1.0; // My measurements bypass the gear reductions. If needed, it's 7.31 to 1.
+  public static final double momentOfInertia = 5; // This is a guess. Units: kilogram meter squared
+  public static final double robotMassKG = 54.4311; // Same as 120 pounds
+  public static final double wheelRadiusMeters = 0.0762;
+  public static final double wheelCircumferenceMeters = 2 * Math.PI * wheelRadiusMeters;
+  public static final double trackWidthMeters = 0.65;
+  public static final double encoderCPR =
+      42.0; // Counts per revolution according to NEO motor datasheet
+  public static final double encoderPPR =
+      encoderCPR / 4; // Pulses per revolution; 1 count is 4 pulses
+  public static final double motorRotationsPerWheelRev =
+      12.1425; // average of 13.732 (right) and 10.553 (left)
+  public static final double distancePerPulse =
+      wheelCircumferenceMeters / (encoderPPR * motorRotationsPerWheelRev);
 
-	// Limelight distance calculation constants
-	// Blitzen config:
-	//public static final double targetHeight = 94.0; // inches
-	//public static final double cameraHeight = 24.0; // inches
-	//public static final double cameraAngle = 30.0; // degrees
+  // File Names
+  public static final String dataStoragePath = "/home/lvuser";
+  public static final String configFileName = "config.yml";
 
-	// 2020 bot config:
-	public static final double targetHeight = 91.5; // inches
-	public static final double cameraHeight = 23.75; // inches
-	public static final double cameraAngle = 29.0; // degrees
-	public static final String comPortsFileName = "com.yml";
+  // Limelight distance calculation constants
+  // Blitzen config:
+  // public static final double targetHeight = 94.0; // inches
+  // public static final double cameraHeight = 24.0; // inches
+  // public static final double cameraAngle = 30.0; // degrees
 
-	/*
-	Tests at Tahoma
-	Front bumper on the line: 3000 RPM, 55 degrees hood, distance 131 inches
-	*/
+  // 2020 bot config:
+  public static final double targetHeight = 91.5; // inches
+  public static final double cameraHeight = 23.75; // inches
+  public static final double cameraAngle = 29.0; // degrees
+  public static final String comPortsFileName = "com.yml";
+
+  /*
+  Tests at Tahoma
+  Front bumper on the line: 3000 RPM, 55 degrees hood, distance 131 inches
+  */
 }

--- a/src/main/java/com/chargerrobotics/Constants.java
+++ b/src/main/java/com/chargerrobotics/Constants.java
@@ -83,22 +83,24 @@ public final class Constants {
   public static final double hoodRetractAngle = 1800;
   public static final double defaultHoodSpeed = 0.30;
 
-  // Autonomous Drive Constants
-  public static final double driveGearRatio =
-      1.0; // My measurements bypass the gear reductions. If needed, it's 7.31 to 1.
-  public static final double momentOfInertia = 5; // This is a guess. Units: kilogram meter squared
-  public static final double robotMassKG = 54.4311; // Same as 120 pounds
-  public static final double wheelRadiusMeters = 0.0762;
-  public static final double wheelCircumferenceMeters = 2 * Math.PI * wheelRadiusMeters;
-  public static final double trackWidthMeters = 0.65;
-  public static final double encoderCPR =
-      42.0; // Counts per revolution according to NEO motor datasheet
-  public static final double encoderPPR =
-      encoderCPR / 4; // Pulses per revolution; 1 count is 4 pulses
-  public static final double motorRotationsPerWheelRev =
-      12.1425; // average of 13.732 (right) and 10.553 (left)
-  public static final double distancePerPulse =
-      wheelCircumferenceMeters / (encoderPPR * motorRotationsPerWheelRev);
+  public static final class DriveMetrics {
+    public static final double DRIVE_GEAR_RATIO =
+        1.0; // My measurements bypass the gear reductions. If needed, it's 7.31 to 1.
+    public static final double MOMENT_OF_INERTIA =
+        5; // This is a guess. Units: kilogram meter squared
+    public static final double ROBOT_MASS_KG = 54.4311; // Same as 120 pounds
+    public static final double WHEEL_RADIUS_METERS = 0.0762;
+    public static final double WHEEL_CIRCUMFERENCE_METERS = 2 * Math.PI * WHEEL_RADIUS_METERS;
+    public static final double TRACK_WIDTH_METERS = 0.65;
+    public static final double ENCODER_CPR =
+        42.0; // Counts per revolution according to NEO motor datasheet
+    public static final double ENCODER_PPR =
+        ENCODER_CPR / 4; // Pulses per revolution; 1 count is 4 pulses
+    public static final double MOTOR_ROTATIONS_PER_WHEEL_REV =
+        12.1425; // average of 13.732 (right) and 10.553 (left)
+    public static final double DISTANCE_PER_PULSE =
+        WHEEL_CIRCUMFERENCE_METERS / (ENCODER_PPR * MOTOR_ROTATIONS_PER_WHEEL_REV);
+  }
 
   // File Names
   public static final String dataStoragePath = "/home/lvuser";

--- a/src/main/java/com/chargerrobotics/Constants.java
+++ b/src/main/java/com/chargerrobotics/Constants.java
@@ -86,9 +86,6 @@ public final class Constants {
   public static final class DriveMetrics {
     public static final double DRIVE_GEAR_RATIO =
         1.0; // My measurements bypass the gear reductions. If needed, it's 7.31 to 1.
-    public static final double MOMENT_OF_INERTIA =
-        5; // This is a guess. Units: kilogram meter squared
-    public static final double ROBOT_MASS_KG = 54.4311; // Same as 120 pounds
     public static final double WHEEL_RADIUS_METERS = 0.0762;
     public static final double WHEEL_CIRCUMFERENCE_METERS = 2 * Math.PI * WHEEL_RADIUS_METERS;
     public static final double TRACK_WIDTH_METERS = 0.65;
@@ -100,6 +97,24 @@ public final class Constants {
         12.1425; // average of 13.732 (right) and 10.553 (left)
     public static final double DISTANCE_PER_PULSE =
         WHEEL_CIRCUMFERENCE_METERS / (ENCODER_PPR * MOTOR_ROTATIONS_PER_WHEEL_REV);
+
+    public static final double MAX_VELOCITY = 3.0; // Meters per second
+    public static final double MAX_ACCEL = 3.0; // Metes squared per second
+
+    // The following values will be updated after running the characterization tool on the robot
+    public static final double KS_VOLTS = 0.22; // Volts to overcome static friction
+    public static final double KV_LINEAR = 1.98; // Volt * seconds per meter
+    public static final double KA_LINEAR = 0.2; // Volt * seconds squared per meter
+    public static final double KV_ANGULAR = 1.5; // Volt * seconds per radian - for simulation
+    public static final double KA_ANGULAR =
+        0.3; // Volt * seconds squared per radian - for simulation
+    public static final double KP = 0.9; // P value for the trajectory-following PID controllers
+    public static final int MAX_DRIVE_VOLTS = 7;
+
+    // According to documentation, the following values produce desirable results
+    public static final double RAMSETE_B =
+        2.0; // Changes how aggressively the velocites are adjusted
+    public static final double RAMSETE_ZETA = 0.7; // Damping value for velocities
   }
 
   // File Names

--- a/src/main/java/com/chargerrobotics/Robot.java
+++ b/src/main/java/com/chargerrobotics/Robot.java
@@ -115,11 +115,13 @@ public class Robot extends TimedRobot {
   /** This function is called once each time the robot enters autonomous mode. */
   @Override
   public void autonomousInit() {
+    ArduinoSerialReceiver.start();
+    robotContainer.setAutonomous();
     if (RobotBase.isReal()) {
-      robotContainer.setAutonomous();
-      ArduinoSerialReceiver.start();
-      robotContainer.leds.setMode(LEDMode.AUTONOMOUS);
-      LimelightSubsystem.getInstance().setLEDStatus(false);
+      robotContainer.leds.setMode(
+          LEDMode
+              .AUTONOMOUS); // According to RobotContainer, the LEDSubsystem will not initialize in
+      // a simulation
     }
   }
 
@@ -130,10 +132,13 @@ public class Robot extends TimedRobot {
   /** This function is called once each time the robot enters test mode. */
   @Override
   public void testInit() {
+    CommandScheduler.getInstance().cancelAll();
+    ArduinoSerialReceiver.close();
     if (RobotBase.isReal()) {
-      CommandScheduler.getInstance().cancelAll();
-      ArduinoSerialReceiver.close();
-      robotContainer.leds.setMode(LEDMode.DISABLED);
+      robotContainer.leds.setMode(
+          LEDMode
+              .DISABLED); // According to RobotContainer, the LEDSubsystem will not initialize in a
+      // simulation
     }
   }
 

--- a/src/main/java/com/chargerrobotics/Robot.java
+++ b/src/main/java/com/chargerrobotics/Robot.java
@@ -123,6 +123,7 @@ public class Robot extends TimedRobot {
               .AUTONOMOUS); // According to RobotContainer, the LEDSubsystem will not initialize in
       // a simulation
     }
+    robotContainer.getAutonomousCommand().schedule();
   }
 
   /** This function is called periodically during autonomous. */

--- a/src/main/java/com/chargerrobotics/Robot.java
+++ b/src/main/java/com/chargerrobotics/Robot.java
@@ -115,10 +115,12 @@ public class Robot extends TimedRobot {
   /** This function is called once each time the robot enters autonomous mode. */
   @Override
   public void autonomousInit() {
-    robotContainer.setAutonomous();
-    ArduinoSerialReceiver.start();
-    robotContainer.leds.setMode(LEDMode.AUTONOMOUS);
-    LimelightSubsystem.getInstance().setLEDStatus(false);
+    if (RobotBase.isReal()) {
+      robotContainer.setAutonomous();
+      ArduinoSerialReceiver.start();
+      robotContainer.leds.setMode(LEDMode.AUTONOMOUS);
+      LimelightSubsystem.getInstance().setLEDStatus(false);
+    }
   }
 
   /** This function is called periodically during autonomous. */
@@ -128,9 +130,11 @@ public class Robot extends TimedRobot {
   /** This function is called once each time the robot enters test mode. */
   @Override
   public void testInit() {
-    CommandScheduler.getInstance().cancelAll();
-    ArduinoSerialReceiver.close();
-    robotContainer.leds.setMode(LEDMode.DISABLED);
+    if (RobotBase.isReal()) {
+      CommandScheduler.getInstance().cancelAll();
+      ArduinoSerialReceiver.close();
+      robotContainer.leds.setMode(LEDMode.DISABLED);
+    }
   }
 
   /** This function is called periodically during test mode. */

--- a/src/main/java/com/chargerrobotics/RobotContainer.java
+++ b/src/main/java/com/chargerrobotics/RobotContainer.java
@@ -329,7 +329,6 @@ public class RobotContainer {
   public void setAutonomous() {
     if (driveEnabled && limelightEnabled) {
       limelightSubsystem.setLEDStatus(true);
-      alignToTarget.schedule();
     }
   }
 

--- a/src/main/java/com/chargerrobotics/RobotContainer.java
+++ b/src/main/java/com/chargerrobotics/RobotContainer.java
@@ -56,7 +56,20 @@ import edu.wpi.cscore.UsbCamera;
 import edu.wpi.first.cameraserver.CameraServer;
 import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj.controller.PIDController;
+import edu.wpi.first.wpilibj.controller.RamseteController;
+import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.trajectory.Trajectory;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
+import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveVoltageConstraint;
+import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import edu.wpi.first.wpilibj2.command.RamseteCommand;
+import java.util.List;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -334,5 +347,45 @@ public class RobotContainer {
 
   public void setDisabled() {
     if (limelightEnabled) limelightSubsystem.setLEDStatus(false);
+  }
+
+  public Command getAutonomousCommand() {
+    DifferentialDriveVoltageConstraint autoVoltageConstraint =
+        new DifferentialDriveVoltageConstraint(
+            new SimpleMotorFeedforward(
+                Constants.DriveMetrics.KS_VOLTS, Constants.DriveMetrics.KV_LINEAR),
+            driveSubsystem.getDriveKinematics(),
+            Constants.DriveMetrics.MAX_DRIVE_VOLTS);
+
+    TrajectoryConfig config =
+        new TrajectoryConfig(Constants.DriveMetrics.MAX_VELOCITY, Constants.DriveMetrics.MAX_ACCEL)
+            .setKinematics(driveSubsystem.getDriveKinematics())
+            .addConstraint(autoVoltageConstraint);
+
+    Trajectory testTrajectory =
+        TrajectoryGenerator.generateTrajectory(
+            new Pose2d(1, 2, new Rotation2d()),
+            List.of(new Translation2d(2, 2)),
+            new Pose2d(4, 2, new Rotation2d()),
+            config);
+
+    RamseteCommand ramseteCommand =
+        new RamseteCommand(
+            testTrajectory,
+            driveSubsystem::getPose,
+            new RamseteController(
+                Constants.DriveMetrics.RAMSETE_B, Constants.DriveMetrics.RAMSETE_ZETA),
+            new SimpleMotorFeedforward(
+                Constants.DriveMetrics.KS_VOLTS,
+                Constants.DriveMetrics.KV_LINEAR,
+                Constants.DriveMetrics.KA_LINEAR),
+            driveSubsystem.getDriveKinematics(),
+            driveSubsystem::getWheelSpeeds,
+            new PIDController(Constants.DriveMetrics.KP, 0, 0),
+            new PIDController(Constants.DriveMetrics.KP, 0, 0),
+            driveSubsystem::tankDriveVolts,
+            driveSubsystem);
+    driveSubsystem.resetPose(testTrajectory.getInitialPose());
+    return ramseteCommand.andThen((() -> driveSubsystem.tankDriveVolts(0, 0)));
   }
 }

--- a/src/main/java/com/chargerrobotics/sensors/GyroscopeSerial.java
+++ b/src/main/java/com/chargerrobotics/sensors/GyroscopeSerial.java
@@ -1,65 +1,88 @@
 package com.chargerrobotics.sensors;
 
-import java.nio.ByteBuffer;
-
 import com.chargerrobotics.utils.ArduinoSerial;
 import com.chargerrobotics.utils.ArduinoSerialReceiver;
 import com.chargerrobotics.utils.ArduinoSerialReceiver.ArduinoListener;
+import java.nio.ByteBuffer;
 
 public class GyroscopeSerial extends ArduinoListener {
 
-	private volatile float x = 0;
-	private volatile float y = 0;
-	private volatile float z = 0;
-	
-	public GyroscopeSerial() {
-		ArduinoSerialReceiver.registerListener(this, (short)0xA02D);
-	}
+  private volatile float x = 0;
+  private volatile float y = 0;
+  private volatile float z = 0;
 
-	public void receiveData(ArduinoSerial serial, ByteBuffer buffer) {
-		if (buffer.remaining() >= 12) {
-			x = buffer.getFloat();
-			y = buffer.getFloat();
-			z = buffer.getFloat();
-		}
-	}
-	
-	/**
-	 * Gets the robot heading in degrees or {@code -1} if data is expired
-	 * 
-	 * Equivalent to {@link #getYaw()}
-	 * 
-	 * @return Robot heading
-	 */
-	public float getHeading() {
-		return getYaw();
-	}
-	
-	/**
-	 * Gets the robot yaw in degrees or {@code -1} if data is expired
-	 * 
-	 * @return Robot yaw
-	 */
-	public float getYaw() {
-		return isExpired() ? -1 : x;
-	}
-	
-	/**
-	 * Gets the robot pitch in degrees or {@code -1} if data is expired
-	 * 
-	 * @return Robot pitch
-	 */
-	public float getPitch() {
-		return isExpired() ? -1 : y;
-	}
-	
-	/**
-	 * Gets the robot roll in degrees or {@code -1} if data is expired
-	 * 
-	 * @return Robot roll
-	 */
-	public float getRoll() {
-		return isExpired() ? -1 : z;
-	}
+  public GyroscopeSerial() {
+    ArduinoSerialReceiver.registerListener(this, (short) 0xA02D);
+  }
 
+  public void receiveData(ArduinoSerial serial, ByteBuffer buffer) {
+    if (buffer.remaining() >= 12) {
+      x = buffer.getFloat();
+      y = buffer.getFloat();
+      z = buffer.getFloat();
+    }
+  }
+
+  /**
+   * Gets the robot heading in degrees or {@code -1} if data is expired
+   *
+   * <p>Equivalent to {@link #getYaw()}
+   *
+   * @return Robot heading
+   */
+  public float getHeading() {
+    return getYaw();
+  }
+
+  /**
+   * Gets the robot heading in radians on the interval [-pi, pi) or {@code -1} if data is expired.
+   * This method is counterclockwise-positive, but the gyro is clockwise positive
+   *
+   * @return Robot heading radians
+   */
+  public float getHeadingRadians() {
+    float headingRad = x;
+    if (headingRad > 180) {
+      headingRad = 360 - x;
+    } else {
+      headingRad = -x;
+    }
+    return isExpired() ? -1 : (float) Math.toRadians(headingRad);
+  }
+
+  /**
+   * Gets the robot yaw in degrees or {@code -1} if data is expired
+   *
+   * @return Robot yaw
+   */
+  public float getYaw() {
+    return isExpired() ? -1 : x;
+  }
+
+  /**
+   * Gets the robot heading without checking if the data is expired.
+   *
+   * @return Robot heading in degrees
+   */
+  public float getRawX() {
+    return x;
+  }
+
+  /**
+   * Gets the robot pitch in degrees or {@code -1} if data is expired
+   *
+   * @return Robot pitch
+   */
+  public float getPitch() {
+    return isExpired() ? -1 : y;
+  }
+
+  /**
+   * Gets the robot roll in degrees or {@code -1} if data is expired
+   *
+   * @return Robot roll
+   */
+  public float getRoll() {
+    return isExpired() ? -1 : z;
+  }
 }

--- a/src/main/java/com/chargerrobotics/sensors/GyroscopeSerial.java
+++ b/src/main/java/com/chargerrobotics/sensors/GyroscopeSerial.java
@@ -35,7 +35,7 @@ public class GyroscopeSerial extends ArduinoListener {
   }
 
   /**
-   * Gets the robot heading in radians on the interval [-pi, pi) or {@code -1} if data is expired.
+   * Gets the robot heading in radians on the interval [-pi, pi) or {@code -9} if data is expired.
    * This method is counterclockwise-positive, but the gyro is clockwise positive
    *
    * @return Robot heading radians
@@ -47,7 +47,7 @@ public class GyroscopeSerial extends ArduinoListener {
     } else {
       headingRad = -x;
     }
-    return isExpired() ? -1 : (float) Math.toRadians(headingRad);
+    return isExpired() ? -9 : (float) Math.toRadians(headingRad);
   }
 
   /**
@@ -64,7 +64,7 @@ public class GyroscopeSerial extends ArduinoListener {
    *
    * @return Robot heading in degrees
    */
-  public float getRawX() {
+  public float getRawYaw() {
     return x;
   }
 

--- a/src/main/java/com/chargerrobotics/subsystems/DriveSubsystem.java
+++ b/src/main/java/com/chargerrobotics/subsystems/DriveSubsystem.java
@@ -202,20 +202,24 @@ public class DriveSubsystem extends SubsystemBase {
   }
 
   public DifferentialDriveWheelSpeeds getWheelSpeeds() {
+    double leftWheelSpeed = 0.0;
+    double rightWheelSpeed = 0.0;
     if (RobotBase.isReal()) {
-      double leftWheelSpeed = // Converts motor RPM to the wheels' velocity in meters per second
+      leftWheelSpeed = // Converts motor RPM to the wheels' velocity in meters per second
           ((leftFront.getEncoder().getVelocity()
                       / Constants.DriveMetrics.MOTOR_ROTATIONS_PER_WHEEL_REV)
                   * Constants.DriveMetrics.WHEEL_CIRCUMFERENCE_METERS)
               / 60;
-      double rightWheelSpeed = // Converts motor RPM to the wheels' velocity in meters per second
+      rightWheelSpeed = // Converts motor RPM to the wheels' velocity in meters per second
           ((rightFront.getEncoder().getVelocity()
                       / Constants.DriveMetrics.MOTOR_ROTATIONS_PER_WHEEL_REV)
                   * Constants.DriveMetrics.WHEEL_CIRCUMFERENCE_METERS)
               / 60;
-      return new DifferentialDriveWheelSpeeds(leftWheelSpeed, rightWheelSpeed);
+    } else {
+      leftWheelSpeed = fakeLeftEncoder.getRate();
+      rightWheelSpeed = fakeRightEncoder.getRate();
     }
-    return new DifferentialDriveWheelSpeeds(fakeLeftEncoder.getRate(), fakeRightEncoder.getRate());
+    return new DifferentialDriveWheelSpeeds(leftWheelSpeed, rightWheelSpeed);
   }
 
   public void resetOdometry() {

--- a/src/main/java/com/chargerrobotics/subsystems/DriveSubsystem.java
+++ b/src/main/java/com/chargerrobotics/subsystems/DriveSubsystem.java
@@ -103,9 +103,9 @@ public class DriveSubsystem extends SubsystemBase {
 
     if (RobotBase.isSimulation()) {
       fakeLeftEncoder = new Encoder(1, 2);
-      fakeLeftEncoder.setDistancePerPulse(Constants.distancePerPulse);
+      fakeLeftEncoder.setDistancePerPulse(Constants.DriveMetrics.DISTANCE_PER_PULSE);
       fakeRightEncoder = new Encoder(3, 4);
-      fakeRightEncoder.setDistancePerPulse(Constants.distancePerPulse);
+      fakeRightEncoder.setDistancePerPulse(Constants.DriveMetrics.DISTANCE_PER_PULSE);
       leftEncoderSim = new EncoderSim(fakeLeftEncoder);
       rightEncoderSim = new EncoderSim(fakeRightEncoder);
       fakeGyro = new AnalogGyro(1);
@@ -114,18 +114,18 @@ public class DriveSubsystem extends SubsystemBase {
       drivetrainSim =
           new DifferentialDrivetrainSim(
               DCMotor.getNEO(2),
-              Constants.driveGearRatio,
-              Constants.momentOfInertia,
-              Constants.robotMassKG,
-              Constants.wheelRadiusMeters,
-              Constants.trackWidthMeters,
+              Constants.DriveMetrics.DRIVE_GEAR_RATIO,
+              Constants.DriveMetrics.MOMENT_OF_INERTIA,
+              Constants.DriveMetrics.ROBOT_MASS_KG,
+              Constants.DriveMetrics.WHEEL_RADIUS_METERS,
+              Constants.DriveMetrics.TRACK_WIDTH_METERS,
               null); // Will not account for sensor measurement noise.
       field = new Field2d();
       SmartDashboard.putData("Field", field);
     }
   }
 
-  public void initOdometry(double x, double y) { // PROBLEMS
+  public void initOdometry(double x, double y) {
     odometry =
         new DifferentialDriveOdometry(
             RobotBase.isReal()
@@ -170,7 +170,9 @@ public class DriveSubsystem extends SubsystemBase {
   }
 
   public double getLeftDistanceMeters() {
-    return leftFront.getEncoder().getPosition() * Constants.encoderPPR * Constants.distancePerPulse;
+    return leftFront.getEncoder().getPosition()
+        * Constants.DriveMetrics.ENCODER_PPR
+        * Constants.DriveMetrics.DISTANCE_PER_PULSE;
   }
 
   public double getOdoRight() {
@@ -179,8 +181,8 @@ public class DriveSubsystem extends SubsystemBase {
 
   public double getRightDistanceMeters() {
     return rightFront.getEncoder().getPosition()
-        * Constants.encoderPPR
-        * Constants.distancePerPulse;
+        * Constants.DriveMetrics.ENCODER_PPR
+        * Constants.DriveMetrics.DISTANCE_PER_PULSE;
   }
 
   public void resetOdometry() {

--- a/src/main/java/com/chargerrobotics/subsystems/DriveSubsystem.java
+++ b/src/main/java/com/chargerrobotics/subsystems/DriveSubsystem.java
@@ -140,7 +140,9 @@ public class DriveSubsystem extends SubsystemBase {
     resetOdometry();
     odometry =
         new DifferentialDriveOdometry(
-            new Rotation2d(getGyroHeadingRadians())); // odometry will always default to
+            new Rotation2d(
+                getGyroHeadingRadians())); // the pose will always default to the origin with a
+    // heading of 0 radians
   }
 
   public void setAutonomousRunning(boolean autonomousRunning) {

--- a/src/main/java/com/chargerrobotics/utils/CANSparkMaxSim.java
+++ b/src/main/java/com/chargerrobotics/utils/CANSparkMaxSim.java
@@ -1,0 +1,59 @@
+package com.chargerrobotics.utils;
+
+import com.revrobotics.CANSparkMax;
+import edu.wpi.first.wpilibj.RobotController;
+
+public class CANSparkMaxSim extends CANSparkMax {
+
+  public double currentSpeed;
+  private boolean inverted;
+
+  public CANSparkMaxSim(int deviceID, MotorType type) {
+    super(deviceID, type);
+    inverted = false;
+  }
+
+  @Override
+  public void pidWrite(double output) {
+    set(output);
+  }
+
+  @Override
+  public void set(double speed) {
+    currentSpeed = inverted ? -speed : speed;
+  }
+
+  @Override
+  public void setVoltage(double outputVolts) {
+    set(outputVolts / RobotController.getBatteryVoltage() * (inverted ? -1 : 1));
+  }
+
+  @Override
+  public double get() {
+    return currentSpeed;
+  }
+
+  public double getCurrentSpeed() {
+    return currentSpeed;
+  }
+
+  @Override
+  public void setInverted(boolean isInverted) {
+    inverted = isInverted;
+  }
+
+  @Override
+  public boolean getInverted() {
+    return inverted;
+  }
+
+  @Override
+  public void disable() {
+    set(0);
+  }
+
+  @Override
+  public void stopMotor() {
+    set(0);
+  }
+}

--- a/src/main/java/com/chargerrobotics/utils/CANSparkMaxSim.java
+++ b/src/main/java/com/chargerrobotics/utils/CANSparkMaxSim.java
@@ -10,6 +10,7 @@ public class CANSparkMaxSim extends CANSparkMax {
 
   public CANSparkMaxSim(int deviceID, MotorType type) {
     super(deviceID, type);
+    currentSpeed = 0.0;
     inverted = false;
   }
 


### PR DESCRIPTION
Closes #16.

This Pull Request will add simulated encoders, a gyro, odometry, a `Field2d` and a `DifferentialDrivetrainSim` model to `DriveSubsystem.java`. When the robot recognizes that it is in a simulation, the model will apply a voltage to the drivetrain based on what voltages the motors are running in. Also, the simulated sensors will update their readings. The readings will be used to update the robot's odometry so that its pose can be represented graphically in a `Field2d` object.

In `Robot.java`, the simulation will crash when selecting certain robot states. The crashes are caused by null-pointer exceptions that are thrown mostly by the Arduino code. This was fixed by adding a `RobotBase.isReal()` check to the existing `Init()` methods.

New constants for the simulation have been added to `Constants.java`. Some of these values will change later on when the robot starts running more in-person tests.

New methods have been added to `GyroscopeSerial.java`. `getHeadingRadians()` will make it more convenient to construct `Rotation2d` objects and `getRawYaw()` will help to address some of the problems that were discovered in #3. 

**March 17**
A `CANSparkMaxSim` class has been created to better mimic the robot's driving behavior. Also, initializing the odometry/pose has been changed in `DriveSubsystem`. The robot pose will always default to the origin with a heading of zero radians. The simulation model has been setup to accommodate for robot characterization constants that will be added in a future Pull Request. In `RobotContainer`, a `RamseteCommand` has been added and scheduled. Currently, there is a trajectory that will make the robot move forward for two meters in a straight line. In the future, code will be added to read and generate trajectories using `json` files from Pathweaver.

Some known issues:

- The `DifferentialDrive` in `DriveSubsystem` needs a separate instance to allow the `RamseteCommand` to run properly.
- In `DriveSubsystem`, the right side motors (or the `rightDriveGroup`) seems to be inverted. Calling `arcadeDrive()` normally seems to cause issues with how the motor speeds are set on both sides. Currently, adjustments have been made on the simulation side to correct for this issue, but getting to the bottom of this would probably be helpful.